### PR TITLE
K2HR3 supports kubernetes pod and container for role member

### DIFF
--- a/index.md
+++ b/index.md
@@ -77,13 +77,15 @@ A very fast and powerful lock library for multithread and multiprocess used in [
 Please refer to the following for details.  
 - **Information aggregation of k2hr3** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3) and {{ page.antpickax_icon }}[**Documents**](https://k2hr3.antpick.ax/)
 
-- **Web Application** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_app)
+- **Web Application** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_app) and {{ page.antpickax_icon }}[**Demonstration**](https://demo.k2hr3.antpick.ax/)
 
 - **REST API** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_api)
 
 - **OpenStack Notification Listener** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_osnl)
 
 - **Utilities** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_utils)
+
+- **Container Registration Sidecar** - {{ page.github_icon }}[**Codes on github**](https://github.com/yahoojapan/k2hr3_sidecar)
 
 ## {{ page.title_k2hdkc }}
 k2hdkc(**k2h**ash based **D**istributed **K**vs **C**luster) is a high performance and horizontal scalable distributed KVS cluster system based on [**k2hash**](https://k2hash.antpick.ax/), [**chmpx**](https://chmpx.antpick.ax/) Distributed Key Value Store(KVS).  

--- a/indexja.md
+++ b/indexja.md
@@ -72,13 +72,15 @@ Yahoo! JAPANでは、多くのオープンソースを利用し、また貢献�
 詳しくは、以下の詳細を参照してください。  
 - **k2hr3全体** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3)、{{ page.antpickax_icon }}[**ドキュメント**](https://k2hr3.antpick.ax/indexja.html)
 
-- **Web Application** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_app)
+- **Web Application** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_app)、{{ page.antpickax_icon }}[**デモンストレーション**](https://demo.k2hr3.antpick.ax/indexja.html)
 
 - **REST API** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_api)
 
 - **OpenStack Notification Listener** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_osnl)
 
 - **Utilities** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_utils)
+
+- **Container Registration Sidecar** - {{ page.github_icon }}[**ソースコード**](https://github.com/yahoojapan/k2hr3_sidecar)
 
 ## {{ page.title_k2hdkc }}
 [**k2hdkc**](https://k2hdkc.antpick.ax/indexja.html)（**K2H**ash based **D**istributed **K**vs **C**luster）は、[**k2hash**](https://k2hash.antpick.ax/indexja.html), [**chmpx**](https://chmpx.antpick.ax/indexja.html)をベースとした高速で自動化された分散KVS（Distributed Key Value Store）です。  


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
K2HR3 now supports kubernetes.
As a result, the content of the gh-pages document has been updated.
